### PR TITLE
Pin reflect-metadata to exactly v0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "jsdom-global": "^2.1.0",
     "mocha": "^3.1.2",
     "node-dependencies": "^0.3.1",
-    "reflect-metadata": "^0.1.8",
+    "reflect-metadata": "0.1.8",
     "rxjs": "^5.0.0-rc.4",
     "ts-npm-lint": "^0.1.0",
     "tslint": "^4.0.1",


### PR DESCRIPTION
Some (theoretically semver-wise) compatible version of `reflect-metadata` later than `0.1.8` breaks the `npm test` command with:

```
var /** @type {?} */ meta = Reflect.getOwnMetadata('propMetadata', target.constructor) || {};
                                                    ^

TypeError: Reflect.getOwnMetadata is not a function
    at PropDecorator (/home/jansen/code/leaflet-ng2/node_modules/@angular/core/bundles/core.umd.js:463:53)
    at DecorateProperty (/home/jansen/code/leaflet-ng2/node_modules/reflect-metadata/Reflect.js:533:29)
    at Object.decorate (/home/jansen/code/leaflet-ng2/node_modules/reflect-metadata/Reflect.js:98:20)
    at __decorate (/home/jansen/code/leaflet-ng2/lib/map.component.js:9:1696)
    at Object.<anonymous> (/home/jansen/code/leaflet-ng2/lib/map.component.js:9:32061)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions.(anonymous function) [as .js] (/home/jansen/code/leaflet-ng2/node_modules/istanbul/lib/hook.js:107:24)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/jansen/code/leaflet-ng2/lib/yaga.module.js:9:1888)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions.(anonymous function) [as .js] (/home/jansen/code/leaflet-ng2/node_modules/istanbul/lib/hook.js:107:24)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/jansen/code/leaflet-ng2/lib/index.js:9:375)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions.(anonymous function) [as .js] (/home/jansen/code/leaflet-ng2/node_modules/istanbul/lib/hook.js:107:24)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/jansen/code/leaflet-ng2/lib/map.component.spec.js:9:51)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions.(anonymous function) [as .js] (/home/jansen/code/leaflet-ng2/node_modules/istanbul/lib/hook.js:107:24)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/jansen/code/leaflet-ng2/test/index.js:8:1)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Object.Module._extensions.(anonymous function) [as .js] (/home/jansen/code/leaflet-ng2/node_modules/istanbul/lib/hook.js:109:37)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at /home/jansen/code/leaflet-ng2/node_modules/mocha/lib/mocha.js:222:27
    at Array.forEach (native)
    at Mocha.loadFiles (/home/jansen/code/leaflet-ng2/node_modules/mocha/lib/mocha.js:219:14)
    at Mocha.run (/home/jansen/code/leaflet-ng2/node_modules/mocha/lib/mocha.js:487:10)
    at Object.<anonymous> (/home/jansen/code/leaflet-ng2/node_modules/mocha/bin/_mocha:459:18)
    at Module._compile (module.js:571:32)
    at Object.Module._extensions..js (module.js:580:10)
    at Object.Module._extensions.(anonymous function) [as .js] (/home/jansen/code/leaflet-ng2/node_modules/istanbul/lib/hook.js:109:37)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12)
    at Function.Module._load (module.js:439:3)
    at Function.Module.runMain (module.js:605:10)
    at runFn (/home/jansen/code/leaflet-ng2/node_modules/istanbul/lib/command/common/run-with-cover.js:122:16)
    at /home/jansen/code/leaflet-ng2/node_modules/istanbul/lib/command/common/run-with-cover.js:251:17
    at /home/jansen/code/leaflet-ng2/node_modules/istanbul/lib/util/file-matcher.js:68:16
    at /home/jansen/code/leaflet-ng2/node_modules/async/lib/async.js:52:16
    at /home/jansen/code/leaflet-ng2/node_modules/async/lib/async.js:361:13
    at /home/jansen/code/leaflet-ng2/node_modules/async/lib/async.js:52:16
    at done (/home/jansen/code/leaflet-ng2/node_modules/async/lib/async.js:246:17)
    at /home/jansen/code/leaflet-ng2/node_modules/async/lib/async.js:44:16
    at /home/jansen/code/leaflet-ng2/node_modules/async/lib/async.js:358:17
    at LOOP (fs.js:1617:14)
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```

This commit suggests to pin the version of `reflect-metadata` to exactly v1.8.0.

Please review.