### PR TITLE
Reference binaries without 'node_modules/.bin' overhead

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "description": "Angular2 module for Leaflet",
   "main": "index.js",
   "scripts": {
-    "init": "npm install && node_modules/.bin/typings install && cp d.ts/leaflet.d.ts typings/globals/leaflet/index.d.ts",
+    "init": "npm install && typings install && cp d.ts/leaflet.d.ts typings/globals/leaflet/index.d.ts",
     "clean": "rm -Rf coverage browser-test/bundle.js lib typings node_modules",
     "reinit": "npm run clean; npm run init",
-    "transpile": "node_modules/.bin/tsc",
-    "lint": "node_modules/.bin/tslint ts/**",
-    "npm-lint": "node_modules/.bin/ts-npm-lint --fix-typings && node_modules/.bin/ts-npm-lint",
-    "test": "npm run lint && npm run transpile && node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -- test/*.js",
+    "transpile": "tsc",
+    "lint": "tslint ts/**",
+    "npm-lint": "ts-npm-lint --fix-typings && ts-npm-lint",
+    "test": "npm run lint && npm run transpile && istanbul cover _mocha -- -- test/*.js",
     "dist": "npm test && npm run npm-lint",
-    "browser-test": "npm run transpile; node_modules/.bin/browserify test/index.js -o browser-test/bundle.js",
-    "doc": "node_modules/.bin/typedoc --out ./typedoc/ --exclude ts/tile-layer.directive.spec.ts --mode file ts/",
-    "dependency-check": "node_modules/.bin/node-dependencies"
+    "browser-test": "npm run transpile; browserify test/index.js -o browser-test/bundle.js",
+    "doc": "typedoc --out ./typedoc/ --exclude ts/tile-layer.directive.spec.ts --mode file ts/",
+    "dependency-check": "node-dependencies"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
When referencing binaries installed as `dependencies` or `devDependencies` through npm scripts, one does not have to specify the full path to the executables. See e.g. http://www.2ality.com/2016/01/locally-installed-npm-executables.html

Without the `node_modules/.bin/`, the scripts also easier to comprehend.

Please review.

(To actually check this in a fresh clone, #98 should be applied first)