### PR TITLE
Enable travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+
+language: node_js
+
+node_js:
+  - "6"
+
+cache:
+  directories:
+    - node_modules
+
+before_script:
+  - npm run init
+
+script:
+  - npm test
+
+branches:
+  only:
+    - develop


### PR DESCRIPTION
This PR suggests to enable Travis CI integration.

Here is the travis log against my forks `develop` branch: https://travis-ci.org/marcjansen/leaflet-ng2/builds/193993250

For travis builds to actually work, an owner of this repo has to enable it (see e.g. [the docs, especially step 2](https://docs.travis-ci.com/user/getting-started#To-get-started-with-Travis-CI%3A)). 

Please review.