### PR TITLE
Enable coverage statistics via coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ before_script:
 script:
   - npm test
 
+after_success:
+  - "cat coverage/lcov.info | ./node_modules/.bin/coveralls"
+
 branches:
   only:
     - develop

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "homepage": "https://github.com/yagajs/leaflet-ng2#readme",
   "devDependencies": {
     "browserify": "^13.1.1",
+    "coveralls": "^2.11.15",
     "istanbul": "^0.4.5",
     "jsdoc": "^3.4.3",
     "jsdom": "^9.8.3",


### PR DESCRIPTION
This PR suggests to send the awesome coverage information on successfull `npm test` to [`coveralls`](https://coveralls.io/).

`coveralls` must be enabled first for this to work.

Please review.