### PR TITLE
#138 Enhance zoom-control example

### DIFF
--- a/examples/zoom-control-directive/index.d.ts
+++ b/examples/zoom-control-directive/index.d.ts
@@ -3,7 +3,7 @@ import 'zone.js';
 import { ControlPosition } from '../../lib/index';
 import { AfterViewInit } from '@angular/core';
 export declare class AppComponent implements AfterViewInit {
-    states: ControlPosition[];
+    positionStates: ControlPosition[];
     position: ControlPosition;
     zoomInText: string;
     zoomInTitle: string;

--- a/examples/zoom-control-directive/index.d.ts
+++ b/examples/zoom-control-directive/index.d.ts
@@ -1,0 +1,18 @@
+import 'reflect-metadata';
+import 'zone.js';
+import { ControlPosition } from '../../lib/index';
+import { AfterViewInit } from '@angular/core';
+export declare class AppComponent implements AfterViewInit {
+    states: ControlPosition[];
+    position: ControlPosition;
+    zoomInText: string;
+    zoomInTitle: string;
+    zoomOutText: string;
+    zoomOutTitle: string;
+    private mapComponent;
+    constructor();
+    handlePositionEvent(event: Event): void;
+    ngAfterViewInit(): void;
+}
+export declare class AppModule {
+}

--- a/examples/zoom-control-directive/index.html
+++ b/examples/zoom-control-directive/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Yaga - Leaflet-NG2 | Tile-Layer Example</title>
+    <title>Yaga - Leaflet-NG2 | Zoom-Control Example</title>
     <script src="bundle.js"></script>
     <link rel="stylesheet" href="../../node_modules/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="../../node_modules/bootstrap/dist/css/bootstrap-theme.min.css" />

--- a/examples/zoom-control-directive/index.ts
+++ b/examples/zoom-control-directive/index.ts
@@ -71,8 +71,8 @@ const template: string = `
     <span class="input-group-addon fixed-space">Position</span>
     
     <select  class="form-control" name="state" [(ngModel)]="position">
-        <option value="" disabled>Choose a state</option>
-        <option *ngFor="let state of states" [ngValue]="state">
+        <option value="" disabled>Choose a position</option>
+        <option *ngFor="let state of positionStates" [ngValue]="state">
         {{ state }}
         </option>
     </select>
@@ -96,7 +96,7 @@ interface ITileLayerOptions {
     template
 })
 export class AppComponent implements AfterViewInit {
-    public states: ControlPosition[]= [
+    public positionStates: ControlPosition[]= [
         'topleft' , 'topright' , 'bottomleft' , 'bottomright'
     ];
     public position: ControlPosition;
@@ -112,7 +112,7 @@ export class AppComponent implements AfterViewInit {
 
     constructor() {
         (<any>window).app = this;
-        this.position = this.states[0];
+        this.position = this.positionStates[0];
     }
 
     public handlePositionEvent(event: Event): void {

--- a/examples/zoom-control-directive/index.ts
+++ b/examples/zoom-control-directive/index.ts
@@ -69,9 +69,7 @@ const template: string = `
     <h3>Control options</h3>   
     <div class="input-group">
     <span class="input-group-addon fixed-space">Position</span>
-    
     <select  class="form-control" name="state" [(ngModel)]="position">
-        <option value="" disabled>Choose a position</option>
         <option *ngFor="let state of positionStates" [ngValue]="state">
         {{ state }}
         </option>

--- a/examples/zoom-control-directive/index.ts
+++ b/examples/zoom-control-directive/index.ts
@@ -15,6 +15,11 @@ const platform: PlatformRef = platformBrowserDynamic();
 
 /* tslint:disable:max-line-length */
 const template: string = `
+
+<div class="container">
+    <h3>Zoom-Control Example</h3>
+</div>
+
 <div class="container">
   <div class="map">
     <yaga-map>
@@ -24,8 +29,11 @@ const template: string = `
       
       <yaga-zoom-control 
          [(position)]="position"
-         [(display)]="display"
-         [zIndex]="zIndex">
+         [zoomInText]="zoomInText"
+         [zoomInTitle]="zoomInTitle"
+         [zoomOutText]="zoomOutText"
+         [zoomOutTitle]="zoomOutTitle"
+      >
       </yaga-zoom-control>
     
     </yaga-map>
@@ -34,8 +42,31 @@ const template: string = `
 </div><!-- /.container -->
 
 <div class="container">
+
+    <h3>Zoom-Control options</h3>
+      
+    <div class="input-group">
+    <span class="input-group-addon fixed-space">zoomInText</span>
+      <input type="text" class="form-control"  [(ngModel)]="zoomInText">
+    </div><!-- /input-group -->
+       
+    <div class="input-group">
+    <span class="input-group-addon fixed-space">zoomInTitle</span>
+      <input type="text" class="form-control"  [(ngModel)]="zoomInTitle">
+    </div><!-- /input-group -->
+        
+    <div class="input-group">
+    <span class="input-group-addon fixed-space">zoomOutText</span>
+      <input type="text" class="form-control"  [(ngModel)]="zoomOutText">
+    </div><!-- /input-group -->
+       
+    <div class="input-group">
+    <span class="input-group-addon fixed-space">zoomOutTitle</span>
+      <input type="text" class="form-control"  [(ngModel)]="zoomOutTitle">
+    </div><!-- /input-group -->
+    
    
-    <h3>Two-Way bound properties</h3>   
+    <h3>Control options</h3>   
     <div class="input-group">
     <span class="input-group-addon fixed-space">Position</span>
     
@@ -46,20 +77,7 @@ const template: string = `
         </option>
     </select>
     </div><!-- /input-group -->
-    
-    
-    <h3>Listener properties</h3>   
-    <h4>Map state changed events</h4>   
-    <div class="input-group">
-        <span class="input-group-addon fixed-space">Display</span>
-        <input type="checkbox" class="form-control"  [(ngModel)]="display">
-    </div><!-- /input-group -->
-        
-    
-    <div class="input-group">
-    <span class="input-group-addon fixed-space">Z-Index</span>
-      <input type="number" class="form-control"  [(ngModel)]="zIndex">
-    </div><!-- /input-group -->
+
     
 
     
@@ -78,15 +96,15 @@ interface ITileLayerOptions {
     template
 })
 export class AppComponent implements AfterViewInit {
-    public zoom: number = 10;
-    public lat: number = 51;
-    public lng: number = 7;
     public states: ControlPosition[]= [
         'topleft' , 'topright' , 'bottomleft' , 'bottomright'
     ];
     public position: ControlPosition;
-    public zIndex: number = 1;
-    public display: boolean = true;
+
+    public zoomInText: string = '+';
+    public zoomInTitle: string = 'Zoom in';
+    public zoomOutText: string = '-';
+    public zoomOutTitle: string ='Zoom out';
 
 
 


### PR DESCRIPTION
Enhancement of the zoom-control example:

added:
- `[zoomInText]`
- `[zoomInTitle]`
- `[zoomOutText]`
- `[zoomOutTitle]`

removed:
- `[display]`
- `[zIndex]`