### PR TITLE
Change the transpile target to es5 again

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@angular/platform-browser": "^4.0.2",
     "@angular/platform-browser-dynamic": "^4.0.2",
     "@types/chai": "^3.5.0",
+    "@types/es6-shim": "^0.31.33",
     "@types/mocha": "^2.2.41",
     "bootstrap": "^3.3.7",
     "browserify": "^14.0.0",
@@ -90,6 +91,7 @@
     "leaflet": "^1.0.3"
   },
   "peerDependencies": {
-    "@angular/core": ">=2.0.0"
+    "@angular/core": ">=2.0.0",
+    "@types/es6-shim": "^0.31.33"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es6",
+        "target": "es5",
         "noImplicitAny": false,
         "sourceMap": true,
         "declaration": true,


### PR DESCRIPTION
Because of compatibility reasons with unglify js and android platforms we decide to switch back to the es5 transpiled version.

We still use Promises in our code, so we need some es6 features, this is why we now need the es6-shim as dependency. Sometimes it causes trouble to use this shim, when another module defines the typings for the es6 functions. This is why we add it as peer dependency and not as a normal dependency!